### PR TITLE
Add support for converting images to stargzify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.12
 
 require (
 	bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
+	github.com/google/go-cmp v0.2.0 // indirect
+	github.com/google/go-containerregistry v0.0.0-20190401170947-eedaddc5e2c8
 	golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53 // indirect
+	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
 	golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,14 @@
 bazil.org/fuse v0.0.0-20180421153158-65cc252bf669 h1:FNCRpXiquG1aoyqcIWVFmpTSKVcx2bQD38uZZeGtdlw=
 bazil.org/fuse v0.0.0-20180421153158-65cc252bf669/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-containerregistry v0.0.0-20190401170947-eedaddc5e2c8 h1:dFHKDxeD4XBwLyUUUDtuBrH/4Hrl++H2Gtv5rOpku7I=
+github.com/google/go-containerregistry v0.0.0-20190401170947-eedaddc5e2c8/go.mod h1:yZAFP63pRshzrEYLXLGPmUt0Ay+2zdjmMN1loCnRLUk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53 h1:kcXqo9vE6fsZY5X5Rd7R1l7fTgnWaDCVmln65REefiE=
 golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
+golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54 h1:xe1/2UUJRmA9iDglQSlkx8c5n3twv58+K0mPpC2zmhA=
 golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/stargz/stargzify/stargzify.go
+++ b/stargz/stargzify/stargzify.go
@@ -2,57 +2,116 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// The stargzify command converts a tarball into a seekable stargz
-// tarball. The output is still a valid tarball, but has new gzip
-// streams throughout the file and and an Table of Contents (TOC)
-// index at the end pointing into those streams.
+// The stargzify command converts a remote container image into an equivalent
+// image with its layers transformed into stargz files instead of gzipped tar
+// files. The image is still a valid container image, but its layers contain
+// multiple gzip streams instead of one and have a Table of Contents at the end.
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"flag"
+	"fmt"
+	"hash"
+	"io"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 
 	"github.com/google/crfs/stargz"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
 var (
-	in  = flag.String("in", "", "input file in tar or tar.gz format. Use \"-\" for stdin.")
-	out = flag.String("out", "", "output file. If empty, it's the input base + \".stargz\", or stdout if the input is stdin. Use \"-\" for stdout.")
+	upgrade = flag.Bool("upgrade", false, "upgrade the image in-place by overwriting the tag")
+	flatten = flag.Bool("flatten", false, "flatten the image's layers into a single layer")
+
+	usage = `usage: %[1]s [-upgrade] [-flatten] input [output]
+
+Converting images:
+  # converts "ubuntu" from dockerhub and uploads to your GCR project
+  %[1]s ubuntu gcr.io/<your-project>/ubuntu:stargz
+
+  # converts and overwrites :latest
+  %[1]s -upgrade gcr.io/<your-project>/ubuntu:latest
+
+  # converts and flattens "ubuntu"
+  %[1]s -flatten ubuntu gcr.io/<your-project>/ubuntu:flattened
+
+Converting files:
+  %[1]s file:/tmp/input.tar.gz file:output.stargz
+
+  # writes to /tmp/input.stargz
+  %[1]s file:/tmp/input.tar.gz
+`
 )
 
 func main() {
 	flag.Parse()
+	if len(flag.Args()) < 1 {
+		printUsage()
+	}
+
+	if strings.HasPrefix(flag.Args()[0], "file:") {
+		// We'll use "file:" prefix as a signal to convert single files.
+		convertFile()
+	} else {
+		convertImage()
+	}
+}
+
+func printUsage() {
+	log.Fatalf(usage, os.Args[0])
+}
+
+func convertFile() {
+	var in, out string
+	if len(flag.Args()) > 0 {
+		in = strings.TrimPrefix(flag.Args()[0], "file:")
+	}
+	if len(flag.Args()) > 1 {
+		out = strings.TrimPrefix(flag.Args()[1], "file:")
+	}
+
 	var f, fo *os.File // file in, file out
 	var err error
-	switch *in {
+	switch in {
 	case "":
-		log.Fatal("missing required --in flag")
+		printUsage()
 	case "-":
 		f = os.Stdin
 	default:
-		f, err = os.Open(*in)
+		f, err = os.Open(in)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 	defer f.Close()
 
-	if *out == "" {
-		if *in == "-" {
-			*out = "-"
+	if out == "" {
+		if in == "-" {
+			out = "-"
 		} else {
-			base := strings.TrimSuffix(*in, ".gz")
+			base := strings.TrimSuffix(in, ".gz")
 			base = strings.TrimSuffix(base, ".tgz")
 			base = strings.TrimSuffix(base, ".tar")
-			*out = base + ".stargz"
+			out = base + ".stargz"
 		}
 	}
-	if *out == "-" {
+	if out == "-" {
 		fo = os.Stdout
 	} else {
-		fo, err = os.Create(*out)
+		fo, err = os.Create(out)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -67,4 +126,207 @@ func main() {
 	if err := fo.Close(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func parseFlags(args []string) (string, string) {
+	if len(args) < 1 {
+		printUsage()
+	}
+
+	var src, dst string
+	src = args[0]
+
+	if len(args) < 2 {
+		if *upgrade {
+			dst = src
+		} else {
+			printUsage()
+		}
+	} else if len(args) == 2 {
+		if *upgrade {
+			log.Println("expected one argument with -upgrade")
+			printUsage()
+		} else {
+			dst = args[1]
+		}
+	} else {
+		log.Println("too many arguments")
+		printUsage()
+	}
+
+	return src, dst
+}
+
+func convertImage() {
+	src, dst := parseFlags(flag.Args())
+	srcRef, err := name.ParseReference(src)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Pull source image.
+	srcImg, err := remote.Image(srcRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Grab original config, clear the layer info from the config file. We want to
+	// preserve the relevant config.
+	srcCfg, err := srcImg.ConfigFile()
+	if err != nil {
+		log.Fatal(err)
+	}
+	srcCfg.RootFS.DiffIDs = []v1.Hash{}
+	srcCfg.History = []v1.History{}
+
+	// Use an empty image with the rest of src's config file as a base.
+	img, err := mutate.ConfigFile(empty.Image, srcCfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	layers, err := convertLayers(srcImg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, layer := range layers {
+		img, err = mutate.Append(img, mutate.Addendum{
+			Layer: layer,
+			History: v1.History{
+				// Leave our mark.
+				CreatedBy: fmt.Sprintf("stargzify %s %s", src, dst),
+			},
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// Push the stargzified image to dst.
+	dstRef, err := name.ParseReference(dst)
+	if err != nil {
+		log.Fatal(err)
+	}
+	dstAuth, err := authn.DefaultKeychain.Resolve(dstRef.Context().Registry)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := remote.Write(dstRef, img, dstAuth, http.DefaultTransport); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func convertLayers(img v1.Image) ([]v1.Layer, error) {
+	if *flatten {
+		r := mutate.Extract(img)
+		return []v1.Layer{newLayer(r)}, nil
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, err
+	}
+
+	converted := []v1.Layer{}
+	for _, layer := range layers {
+		r, err := layer.Uncompressed()
+		if err != nil {
+			return nil, err
+		}
+		converted = append(converted, newLayer(r))
+	}
+
+	return converted, nil
+}
+
+type layer struct {
+	rc     io.ReadCloser
+	d      *digester
+	diff   *v1.Hash
+	digest *v1.Hash
+}
+
+// newLayer converts the given io.ReadCloser to a stargz layer.
+func newLayer(rc io.ReadCloser) v1.Layer {
+	return &layer{
+		rc: rc,
+		d: &digester{
+			h: sha256.New(),
+		},
+	}
+}
+
+func (l *layer) Digest() (v1.Hash, error) {
+	if l.digest == nil {
+		return v1.Hash{}, stream.ErrNotComputed
+	}
+	return *l.digest, nil
+}
+
+func (l *layer) Size() (int64, error) {
+	if l.digest == nil {
+		return -1, stream.ErrNotComputed
+	}
+	return l.d.n, nil
+}
+
+func (l *layer) DiffID() (v1.Hash, error) {
+	if l.diff == nil {
+		return v1.Hash{}, stream.ErrNotComputed
+	}
+	return *l.diff, nil
+}
+
+func (l *layer) MediaType() (types.MediaType, error) {
+	// TODO: We might want to set our own media type to indicate stargz layers,
+	// but that has the potential to break registry compatibility.
+	return types.DockerLayer, nil
+}
+
+func (l *layer) Compressed() (io.ReadCloser, error) {
+	pr, pw := io.Pipe()
+
+	// Convert input blob to stargz while computing diffid, digest, and size.
+	go func() {
+		w := stargz.NewWriter(pw)
+		if err := w.AppendTar(l.rc); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if err := w.Close(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		diffid, err := v1.NewHash(w.DiffID())
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		l.diff = &diffid
+		l.digest = &v1.Hash{
+			Algorithm: "sha256",
+			Hex:       hex.EncodeToString(l.d.h.Sum(nil)),
+		}
+		pw.Close()
+	}()
+
+	return ioutil.NopCloser(io.TeeReader(pr, l.d)), nil
+}
+
+func (l *layer) Uncompressed() (io.ReadCloser, error) {
+	return l.rc, nil
+}
+
+// digester tracks the sha256 and length of what is written to it.
+type digester struct {
+	h hash.Hash
+	n int64
+}
+
+func (d *digester) Write(b []byte) (int, error) {
+	n, err := d.h.Write(b)
+	d.n += int64(n)
+	return n, err
 }


### PR DESCRIPTION
A version of stargzify that works against container registries.

We probably want a better name and different flags, but this is a start. We also might want to make layer flattening optional?