### PR TITLE
crfs: mount crfs read-only

### DIFF
--- a/crfs.go
+++ b/crfs.go
@@ -65,7 +65,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	c, err := fuse.Mount(mntPoint, fuse.FSName("crfs"), fuse.Subtype("crfs"))
+	c, err := fuse.Mount(mntPoint, fuse.FSName("crfs"), fuse.Subtype("crfs"), fuse.ReadOnly())
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Before:

```
crfs /tmp/crfs/test1 fuse.crfs rw,nosuid,nodev,relatime,user_id=0,group_id=0 0 0
```

After

```
crfs /tmp/crfs/test1 fuse.crfs ro,nosuid,nodev,relatime,user_id=0,group_id=0 0 0
```