### PR TITLE
crfs: unmount filesystem when exit

### DIFF
--- a/crfs.go
+++ b/crfs.go
@@ -70,6 +70,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
+	defer fuse.Unmount(mntPoint)
 
 	err = fspkg.Serve(c, fs)
 	if err != nil {


### PR DESCRIPTION
We should unmount the filesystem when exit or we will fail when we run `crfs` next time.

```
2019/03/23 23:20:14 mount helper error: fusermount: failed to open mountpoint for reading: Transport endpoint is not connected
2019/03/23 23:20:14 fusermount: exit status 1
```

Also, we should handle OS's signal. 