### PR TITLE
stargz: fix lookup for last chunk

### DIFF
--- a/stargz/stargz.go
+++ b/stargz/stargz.go
@@ -443,8 +443,8 @@ func (fr *fileReader) ReadAt(p []byte, off int64) (n int, err error) {
 		i = sort.Search(len(fr.ents), func(i int) bool {
 			return fr.ents[i].ChunkOffset >= off
 		})
-		if i == -1 {
-			return 0, errors.New("internal error; error finding chunk given offset")
+		if i == len(fr.ents) {
+			i = len(fr.ents) - 1
 		}
 	}
 	ent := fr.ents[i]

--- a/stargz/stargz_test.go
+++ b/stargz/stargz_test.go
@@ -129,6 +129,7 @@ func TestWriteAndOpen(t *testing.T) {
 				hasFileContentsRange("foo/big.txt", 10, "ch a big file"),
 				hasFileContentsRange("foo/big.txt", 11, "h a big file"),
 				hasFileContentsRange("foo/big.txt", 12, " a big file"),
+				hasFileContentsRange("foo/big.txt", len("This is such a big file")-1, ""),
 				hasChunkEntries("foo/big.txt", 6),
 			),
 		},


### PR DESCRIPTION
sort.Search fails only when the specified offset is after the last
chunk.  When it happens, attempt to use the last chunk.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>