### PR TITLE
Provide same Node instance for same file not to make overlayfs confused.

### DIFF
--- a/crfs.go
+++ b/crfs.go
@@ -904,10 +904,10 @@ type node struct {
 	sr *stargz.Reader
 	f  *os.File // non-nil if root & in debug mode
 
-	mu sync.Mutex // For children maps.
-	// children maps from previously-looked up base names (like "foo.txt") to
-	// the *node that was previously returned. This prevents FUSE inode numbers
-	// from getting out of sync
+	mu sync.Mutex // guards child, below
+	// child maps from previously-looked up base names (like "foo.txt") to the *node
+	// that was previously returned. This prevents FUSE inode numbers from getting
+	// out of sync
 	child map[string]*node
 }
 

--- a/crfs.go
+++ b/crfs.go
@@ -974,6 +974,8 @@ func (h *nodeHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err er
 //
 // See https://godoc.org/bazil.org/fuse/fs#NodeStringLookuper
 func (n *node) Lookup(ctx context.Context, name string) (fspkg.Node, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
     	if c, ok := n.child[name] ; ok {
     		return c, nil
     	}
@@ -989,15 +991,7 @@ func (n *node) Lookup(ctx context.Context, name string) (fspkg.Node, error) {
 		sr: n.sr,
 		child: make(map[string]*node),
 	}
-	n.mu.Lock()
-	if c2, ok := n.child[name] ; ok {
-		// Someone generated node object during our looking up.
-		// In this case, we use this registered one not to make kernel confused.
-		c = c2
-	} else {
-		n.child[name] = c
-	}
-	n.mu.Unlock()
+	n.child[name] = c
 	
     	return c, nil
 }

--- a/crfs.go
+++ b/crfs.go
@@ -470,10 +470,10 @@ func (n *layerDebugRoot) Lookup(ctx context.Context, name string) (fspkg.Node, e
 		return nil, errors.New("failed to find root in stargz")
 	}
 	return &node{
-		fs: n.fs,
-		te: root,
-		sr: r,
-		f:  f,
+		fs:    n.fs,
+		te:    root,
+		sr:    r,
+		f:     f,
 		child: make(map[string]*node),
 	}, nil
 }
@@ -773,9 +773,9 @@ func (n *layerHostOwnerImageReference) Lookup(ctx context.Context, name string) 
 		return nil, errors.New("failed to find root in stargz")
 	}
 	return &node{
-		fs: n.fs,
-		te: root,
-		sr: r,
+		fs:    n.fs,
+		te:    root,
+		sr:    r,
 		child: make(map[string]*node),
 	}, nil
 }
@@ -976,24 +976,24 @@ func (h *nodeHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err er
 func (n *node) Lookup(ctx context.Context, name string) (fspkg.Node, error) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-    	if c, ok := n.child[name] ; ok {
-    		return c, nil
-    	}
+	if c, ok := n.child[name]; ok {
+		return c, nil
+	}
 
 	e, ok := n.te.LookupChild(name)
 	if !ok {
 		return nil, fuse.ENOENT
 	}
-	
-    	c := &node{
-		fs: n.fs,
-		te: e,
-		sr: n.sr,
+
+	c := &node{
+		fs:    n.fs,
+		te:    e,
+		sr:    n.sr,
 		child: make(map[string]*node),
 	}
 	n.child[name] = c
-	
-    	return c, nil
+
+	return c, nil
 }
 
 // Readlink reads the target of a symlink.


### PR DESCRIPTION
Fixes: #16 

CRFS currently doesn't support to merge the layers using overlayfs.

CRFS [generates different "Node" instance](https://github.com/google/crfs/blob/192c6996c1c7acc6fd7974eec1d83ec09ee7e876/crfs.go#L973) every time "Lookup" is called. This behaviour makes bazil/fuse assign different "Node IDs"(used by FUSE) to inodes every time even if these "Lookups" point to same file because [bazil/fuse caches "Node IDs" keyed by a "Node" instance (not an inode number etc.)](https://github.com/bazil/fuse/blob/65cc252bf6691cb3c7014bcb2c8dc29de91e3a7e/fs/serve.go#L486). Most time (when we don't use overlayfs etc.) it is fine.

However, when [dentry cache revalidation](https://www.kernel.org/doc/Documentation/filesystems/vfs.txt) is executed and the dentry is expired (by default, set to 1 min in [bazil/fuse](https://github.com/bazil/fuse/blob/65cc252bf6691cb3c7014bcb2c8dc29de91e3a7e/fs/serve.go#L29).), FUSE ["lookups" the original inode](https://github.com/torvalds/linux/blob/d8a5b80568a9cb66810e75b182018e9edb68e8ff/fs/fuse/dir.c#L219) and it [doesn't allow different Node IDs to same inode](https://github.com/torvalds/linux/blob/d8a5b80568a9cb66810e75b182018e9edb68e8ff/fs/fuse/dir.c#L226) and concludes the cache as invalid. Unfortunately, overlayfs [doesn't allow dentry caches being invalid](https://github.com/torvalds/linux/blob/d8a5b80568a9cb66810e75b182018e9edb68e8ff/fs/overlayfs/super.c#L145) and returns ESTALE.

This commit solves this issue and make CRFS support overlayfs by cache node
instances in CRFS once it looked-up and using it when the same name is looked
up.
