### PR TITLE
Record link counts in each entry and resolve hardlinks on each lookin…

### DIFF
--- a/crfs.go
+++ b/crfs.go
@@ -946,7 +946,10 @@ func (n *node) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Uid = uint32(n.te.Uid)
 	a.Gid = uint32(n.te.Gid)
 	a.Rdev = uint32(unix.Mkdev(uint32(n.te.DevMajor), uint32(n.te.DevMinor)))
-	a.Nlink = uint32(n.te.NumLink + 1)
+	a.Nlink = uint32(n.te.NumLink)
+	if a.Nlink == 0 {
+		a.Nlink = 1 // zero "NumLink" means one so we map them here.
+	}
 	if debug {
 		log.Printf("attr of %s: %s", n.te.Name, *a)
 	}

--- a/crfs.go
+++ b/crfs.go
@@ -946,7 +946,7 @@ func (n *node) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Uid = uint32(n.te.Uid)
 	a.Gid = uint32(n.te.Gid)
 	a.Rdev = uint32(unix.Mkdev(uint32(n.te.DevMajor), uint32(n.te.DevMinor)))
-	a.Nlink = uint32(n.te.Nlink)
+	a.Nlink = uint32(n.te.NumLink + 1)
 	if debug {
 		log.Printf("attr of %s: %s", n.te.Name, *a)
 	}

--- a/crfs.go
+++ b/crfs.go
@@ -946,7 +946,7 @@ func (n *node) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Uid = uint32(n.te.Uid)
 	a.Gid = uint32(n.te.Gid)
 	a.Rdev = uint32(unix.Mkdev(uint32(n.te.DevMajor), uint32(n.te.DevMinor)))
-	a.Nlink = 1 // TODO: get this from te once hardlinks are more supported
+	a.Nlink = uint32(n.te.Nlink)
 	if debug {
 		log.Printf("attr of %s: %s", n.te.Name, *a)
 	}

--- a/stargz/stargz.go
+++ b/stargz/stargz.go
@@ -327,6 +327,7 @@ func (r *Reader) initFields() error {
 			name = strings.TrimSuffix(name, "/")
 		}
 		pdir := r.getOrCreateDir(parentDir(name))
+		ent.NumLink++ // at least one name(ent.Name) references this entry.
 		if ent.Type == "hardlink" {
 			if org, ok := r.m[ent.LinkName]; ok {
 				org.NumLink++ // original entry is referenced by this ent.Name.

--- a/stargz/stargz_test.go
+++ b/stargz/stargz_test.go
@@ -161,9 +161,9 @@ func TestWriteAndOpen(t *testing.T) {
 			),
 			wantNumGz: 3,
 			want: checks(
-				lookupMatch("b", &TOCEntry{Name: "b", Type: "block", DevMajor: 123, DevMinor: 456}),
-				lookupMatch("c", &TOCEntry{Name: "c", Type: "char", DevMajor: 111, DevMinor: 222}),
-				lookupMatch("f", &TOCEntry{Name: "f", Type: "fifo"}),
+				lookupMatch("b", &TOCEntry{Name: "b", Type: "block", DevMajor: 123, DevMinor: 456, Nlink: 1}),
+				lookupMatch("c", &TOCEntry{Name: "c", Type: "char", DevMajor: 111, DevMinor: 222, Nlink: 1}),
+				lookupMatch("f", &TOCEntry{Name: "f", Type: "fifo", Nlink: 1}),
 			),
 		},
 	}

--- a/stargz/stargz_test.go
+++ b/stargz/stargz_test.go
@@ -161,9 +161,9 @@ func TestWriteAndOpen(t *testing.T) {
 			),
 			wantNumGz: 3,
 			want: checks(
-				lookupMatch("b", &TOCEntry{Name: "b", Type: "block", DevMajor: 123, DevMinor: 456, Nlink: 1}),
-				lookupMatch("c", &TOCEntry{Name: "c", Type: "char", DevMajor: 111, DevMinor: 222, Nlink: 1}),
-				lookupMatch("f", &TOCEntry{Name: "f", Type: "fifo", Nlink: 1}),
+				lookupMatch("b", &TOCEntry{Name: "b", Type: "block", DevMajor: 123, DevMinor: 456, NumLink: 1}),
+				lookupMatch("c", &TOCEntry{Name: "c", Type: "char", DevMajor: 111, DevMinor: 222, NumLink: 1}),
+				lookupMatch("f", &TOCEntry{Name: "f", Type: "fifo", NumLink: 1}),
 			),
 		},
 	}


### PR DESCRIPTION
Fixes: #20

Currently we can't deal with hard-link and there are two causes:
- In `TOCEntriy`s, link counts aren't recorded and the filesystem returns a
  static number "1" as link counts.
- When a filesystem looksup to a stargz file (with `stargz.Reader.Lookup()` or
  `(*stargz.TOCEntry).LookupChild()`), the hardlink isn't resolved.

This commit solves this issue by making a TOCEntry field which records each
entry's link counts and by resolving hardlinks on every lookingup.
