### PR TITLE
Ensure writing to the digester completes before the digest calculation.

### DIFF
--- a/stargz/stargzify/stargzify.go
+++ b/stargz/stargzify/stargzify.go
@@ -290,7 +290,7 @@ func (l *layer) Compressed() (io.ReadCloser, error) {
 
 	// Convert input blob to stargz while computing diffid, digest, and size.
 	go func() {
-		w := stargz.NewWriter(pw)
+		w := stargz.NewWriter(io.MultiWriter(pw, l.d))
 		if err := w.AppendTar(l.rc); err != nil {
 			pw.CloseWithError(err)
 			return
@@ -312,7 +312,7 @@ func (l *layer) Compressed() (io.ReadCloser, error) {
 		pw.Close()
 	}()
 
-	return ioutil.NopCloser(io.TeeReader(pr, l.d)), nil
+	return ioutil.NopCloser(pr), nil
 }
 
 func (l *layer) Uncompressed() (io.ReadCloser, error) {


### PR DESCRIPTION
Sometimes, stargzifying an image fails with DIGEST_INVALID.

There is a race condition on the `digester`.
The method `layer.Compressed()` calculates the digest(with `Sum()` method)
immediately after the `PipeWriter` is unblocked. But even if the `PipeWriter` is
unblocked, it isn't guaranteed that the `TeeReader` completes writing the data
to the `digester`.

This commit solves this issue by ensuring wrinting to the `digester` completes
before the digest calculation using `MultiWriter` instead of `TeeReader`.
