### PR TITLE
stargz: include empty files in the TOC

### DIFF
--- a/stargz/stargz.go
+++ b/stargz/stargz.go
@@ -711,7 +711,7 @@ func (w *Writer) AppendTar(r io.Reader) error {
 			return fmt.Errorf("unsupported input tar entry %q", h.Typeflag)
 		}
 
-		if h.Typeflag == tar.TypeReg {
+		if h.Typeflag == tar.TypeReg && ent.Size > 0 {
 			var written int64
 			totalSize := ent.Size // save it before we destroy ent
 			for written < totalSize {

--- a/stargz/stargz_test.go
+++ b/stargz/stargz_test.go
@@ -56,6 +56,20 @@ func TestWriteAndOpen(t *testing.T) {
 			),
 		},
 		{
+			name: "1dir_1empty_file",
+			in: tarOf(
+				dir("foo/"),
+				file("foo/bar.txt", ""),
+			),
+			wantNumGz: 3, // dir, TOC, footer
+			want: checks(
+				numTOCEntries(2),
+				hasDir("foo/"),
+				hasFileLen("foo/bar.txt", 0),
+				entryHasChildren("foo", "bar.txt"),
+			),
+		},
+		{
 			name: "1dir_1file",
 			in: tarOf(
 				dir("foo/"),


### PR DESCRIPTION
make sure that empty files are not lost when the image is converted to
the stargz format.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>