### PR TITLE
Reserve TOC JSON filename to avoid duplicated entries in a stargzifed layer

### DIFF
--- a/stargz/stargz.go
+++ b/stargz/stargz.go
@@ -671,6 +671,12 @@ func (w *Writer) AppendTar(r io.Reader) error {
 		if err != nil {
 			return fmt.Errorf("error reading from source tar: tar.Reader.Next: %v", err)
 		}
+		if h.Name == TOCTarName {
+			// It is possible for a layer to be "stargzified" twice during the
+			// distribution lifecycle. So we reserve "TOCTarName" here to avoid
+			// duplicated entries in the resulting layer.
+			continue
+		}
 		ent := &TOCEntry{
 			Name:        h.Name,
 			Mode:        h.Mode,


### PR DESCRIPTION
Fixes: #27

It is possible for a layer to be stargzified twice during the distribution
lifecycle, which currently results in a broken layer. The reason is the name of
TOC JSON file("stargz.index.json") isn't reserved and duplicates in the
stargzified layer.

This commit solves this issue by reserving the TOC JSON filename when
stargzifying a layer.