### PR TITLE
Support whiteout entries in overlayfs

### DIFF
--- a/crfs.go
+++ b/crfs.go
@@ -52,6 +52,21 @@ const debug = false
 
 var (
 	fuseDebug = flag.Bool("fuse_debug", false, "enable verbose FUSE debugging")
+
+	// A "whiteout" file is an empty file with a special filename that signifies a
+	// path should be deleted. Whiteouts have special prefix ".wh.".
+	// See https://github.com/opencontainers/image-spec/blob/775207bd45b6cb8153ce218cc59351799217451f/layer.md#whiteouts
+	whiteoutPrefix = ".wh."
+
+	// "Opaque whiteout" indicates that all siblings are hidden in the lower layer.
+	// See https://github.com/opencontainers/image-spec/blob/775207bd45b6cb8153ce218cc59351799217451f/layer.md#opaque-whiteout
+	whiteoutOpaqueDir = whiteoutPrefix + whiteoutPrefix + ".opq"
+
+	// In the overlayfs, a directory is made opaque by setting the xattr
+	// "trusted.overlay.opaque" to "y".
+	// See https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt
+	opaqueXattr      = "trusted.overlay.opaque"
+	opaqueXattrValue = "y"
 )
 
 func usage() {
@@ -474,7 +489,7 @@ func (n *layerDebugRoot) Lookup(ctx context.Context, name string) (fspkg.Node, e
 		te:    root,
 		sr:    r,
 		f:     f,
-		child: make(map[string]*node),
+		child: make(map[string]fspkg.Node),
 	}, nil
 }
 
@@ -776,7 +791,7 @@ func (n *layerHostOwnerImageReference) Lookup(ctx context.Context, name string) 
 		fs:    n.fs,
 		te:    root,
 		sr:    r,
-		child: make(map[string]*node),
+		child: make(map[string]fspkg.Node),
 	}, nil
 }
 
@@ -899,16 +914,17 @@ func direntType(ent *stargz.TOCEntry) fuse.DirentType {
 // node is a CRFS node in the FUSE filesystem.
 // See https://godoc.org/bazil.org/fuse/fs#Node
 type node struct {
-	fs *FS
-	te *stargz.TOCEntry
-	sr *stargz.Reader
-	f  *os.File // non-nil if root & in debug mode
+	fs     *FS
+	te     *stargz.TOCEntry
+	sr     *stargz.Reader
+	f      *os.File // non-nil if root & in debug mode
+	opaque bool     // true if this node is an overlayfs opaque directory
 
 	mu sync.Mutex // guards child, below
 	// child maps from previously-looked up base names (like "foo.txt") to the *node
 	// that was previously returned. This prevents FUSE inode numbers from getting
 	// out of sync
-	child map[string]*node
+	child map[string]fspkg.Node
 }
 
 var (
@@ -961,7 +977,20 @@ func (n *node) Attr(ctx context.Context, a *fuse.Attr) error {
 // https://godoc.org/bazil.org/fuse/fs#HandleReadDirAller
 func (h *nodeHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err error) {
 	n := h.n
+	whiteouts := map[string]*stargz.TOCEntry{}
+	normalents := map[string]struct{}{}
 	n.te.ForeachChild(func(baseName string, ent *stargz.TOCEntry) bool {
+		// We don't want to show ".wh."-prefixed whiteout files.
+		if strings.HasPrefix(baseName, whiteoutPrefix) {
+			if baseName == whiteoutOpaqueDir {
+				return true
+			}
+			// Add an overlayfs-styled whiteout direntry later.
+			whiteouts[baseName] = ent
+			return true
+		}
+
+		normalents[baseName] = struct{}{}
 		ents = append(ents, fuse.Dirent{
 			Inode: inodeOfEnt(ent),
 			Type:  direntType(ent),
@@ -969,6 +998,18 @@ func (h *nodeHandle) ReadDirAll(ctx context.Context) (ents []fuse.Dirent, err er
 		})
 		return true
 	})
+
+	// Append whiteouts if no entry replaces the target entry in the lower layer.
+	for w, ent := range whiteouts {
+		if _, ok := normalents[w[len(whiteoutPrefix):]]; !ok {
+			ents = append(ents, fuse.Dirent{
+				Inode: inodeOfEnt(ent),
+				Type:  fuse.DT_Char,
+				Name:  w[len(whiteoutPrefix):],
+			})
+
+		}
+	}
 	sort.Slice(ents, func(i, j int) bool { return ents[i].Name < ents[j].Name })
 	return ents, nil
 }
@@ -983,16 +1024,34 @@ func (n *node) Lookup(ctx context.Context, name string) (fspkg.Node, error) {
 		return c, nil
 	}
 
-	e, ok := n.te.LookupChild(name)
-	if !ok {
+	// We don't want to show ".wh."-prefixed whiteout files.
+	if strings.HasPrefix(name, whiteoutPrefix) {
 		return nil, fuse.ENOENT
 	}
 
+	e, ok := n.te.LookupChild(name)
+	if !ok {
+		// If the entry exists as a whiteout, show an overlayfs-styled whiteout node.
+		if e, ok := n.te.LookupChild(fmt.Sprintf("%s%s", whiteoutPrefix, name)); ok {
+			c := &whiteout{e}
+			n.child[name] = c
+			return c, nil
+		}
+		return nil, fuse.ENOENT
+	}
+
+	var opaque bool
+	if _, ok := e.LookupChild(whiteoutOpaqueDir); ok {
+		// This entry is an opaque directory.
+		opaque = true
+	}
+
 	c := &node{
-		fs:    n.fs,
-		te:    e,
-		sr:    n.sr,
-		child: make(map[string]*node),
+		fs:     n.fs,
+		te:     e,
+		sr:     n.sr,
+		child:  make(map[string]fspkg.Node),
+		opaque: opaque,
 	}
 	n.child[name] = c
 
@@ -1014,6 +1073,10 @@ func (n *node) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string,
 // See https://godoc.org/bazil.org/fuse/fs#NodeListxattrer
 func (n *node) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
 	var allXattrs []byte
+	if n.opaque {
+		// This node is an opaque directory so add overlayfs-compliant indicator.
+		allXattrs = append(append(allXattrs, []byte(opaqueXattr)...), 0)
+	}
 	for k, _ := range n.te.Xattrs {
 		allXattrs = append(append(allXattrs, []byte(k)...), 0)
 	}
@@ -1030,8 +1093,15 @@ func (n *node) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *
 //
 // See https://godoc.org/bazil.org/fuse/fs#NodeGetxattrer
 func (n *node) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
-
-	xattr := n.te.Xattrs[req.Name]
+	var xattr []byte
+	if req.Name == opaqueXattr {
+		if n.opaque {
+			// This node is an opaque directory so give overlayfs-compliant indicator.
+			xattr = []byte(opaqueXattrValue)
+		}
+	} else {
+		xattr = n.te.Xattrs[req.Name]
+	}
 	if req.Position >= uint32(len(xattr)) {
 		resp.Xattr = []byte{}
 		return nil
@@ -1054,6 +1124,22 @@ func (n *node) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 		}
 	}
 	return h, nil
+}
+
+// whiteout is an overlayfs whiteout file which is a character device with 0/0
+// device number.
+// See https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt
+type whiteout struct {
+	te *stargz.TOCEntry
+}
+
+func (w *whiteout) Attr(ctx context.Context, a *fuse.Attr) error {
+	a.Valid = 30 * 24 * time.Hour
+	a.Inode = inodeOfEnt(w.te)
+	a.Mode = os.ModeDevice | os.ModeCharDevice
+	a.Rdev = uint32(unix.Mkdev(0, 0))
+	a.Nlink = 1
+	return nil
 }
 
 // nodeHandle is a node that's been opened (opendir or for read).

--- a/crfs.go
+++ b/crfs.go
@@ -926,9 +926,9 @@ type node struct {
 	opaque bool     // true if this node is an overlayfs opaque directory
 
 	mu sync.Mutex // guards child, below
-	// child maps from previously-looked up base names (like "foo.txt") to the *node
-	// that was previously returned. This prevents FUSE inode numbers from getting
-	// out of sync
+	// child maps from previously-looked up base names (like "foo.txt") to the
+	// fspkg.Node that was previously returned. This prevents FUSE inode numbers
+	// from getting out of sync
 	child map[string]fspkg.Node
 }
 

--- a/crfs_test.go
+++ b/crfs_test.go
@@ -443,18 +443,17 @@ func hasNodeXattrs(entry, name, value string) crfsCheck {
 			}
 		}
 		if !found {
-			t.Errorf("node %q doesn't have an opaque xattr %q", entry, opaqueXattr)
+			t.Errorf("node %q doesn't have an xattr %q", entry, name)
 			return
 		}
 
 		// check the xattr has valid value.
 		getres := fuse.GetxattrResponse{}
 		if err := n.Getxattr(context.Background(), &fuse.GetxattrRequest{Name: name}, &getres); err != nil {
-			t.Fatalf("failed to get xattr %q of node %q: %v", opaqueXattr, entry, err)
+			t.Fatalf("failed to get xattr %q of node %q: %v", name, entry, err)
 		}
 		if string(getres.Xattr) != value {
-			t.Errorf("node %q has an invalid opaque directory xattr %q; want %q",
-				entry, getres.Xattr, opaqueXattrValue)
+			t.Errorf("node %q has an invalid xattr %q; want %q", entry, getres.Xattr, value)
 			return
 		}
 	})

--- a/crfs_test.go
+++ b/crfs_test.go
@@ -8,14 +8,19 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"bazil.org/fuse"
+	fspkg "bazil.org/fuse/fs"
 	"github.com/google/crfs/stargz"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -167,4 +172,353 @@ func buildSingleFileTar(t *testing.T, name string, contents []byte) (r io.Reader
 		return
 	}()
 	return pr, func() { go pr.Close(); go pw.Close() }
+}
+
+// Tests if whiteouts are overlayfs-compatible.
+func TestWhiteout(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []tarEntry
+		want []crfsCheck
+	}{
+		{
+			name: "1_whiteout_with_sibling",
+			in: tarOf(
+				dir("foo/"),
+				file("foo/bar.txt", ""),
+				file("foo/.wh.foo.txt", ""),
+			),
+			want: checks(
+				hasValidWhiteout("foo/foo.txt"),
+				fileNotExist("foo/.wh.foo.txt"),
+			),
+		},
+		{
+			name: "1_whiteout_with_duplicated_name",
+			in: tarOf(
+				dir("foo/"),
+				file("foo/bar.txt", "test"),
+				file("foo/.wh.bar.txt", ""),
+			),
+			want: checks(
+				hasFileDigest("foo/bar.txt", digestFor("test")),
+				fileNotExist("foo/.wh.bar.txt"),
+			),
+		},
+		{
+			name: "1_opaque",
+			in: tarOf(
+				dir("foo/"),
+				file("foo/.wh..wh..opq", ""),
+			),
+			want: checks(
+				hasNodeXattrs("foo/", opaqueXattr, opaqueXattrValue),
+				fileNotExist("foo/.wh..wh..opq"),
+			),
+		},
+		{
+			name: "1_opaque_with_sibling",
+			in: tarOf(
+				dir("foo/"),
+				file("foo/.wh..wh..opq", ""),
+				file("foo/bar.txt", "test"),
+			),
+			want: checks(
+				hasNodeXattrs("foo/", opaqueXattr, opaqueXattrValue),
+				hasFileDigest("foo/bar.txt", digestFor("test")),
+				fileNotExist("foo/.wh..wh..opq"),
+			),
+		},
+		{
+			name: "1_opaque_with_xattr",
+			in: tarOf(
+				dir("foo/", xAttr{"foo": "bar"}),
+				file("foo/.wh..wh..opq", ""),
+			),
+			want: checks(
+				hasNodeXattrs("foo/", opaqueXattr, opaqueXattrValue),
+				hasNodeXattrs("foo/", "foo", "bar"),
+				fileNotExist("foo/.wh..wh..opq"),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, cancel := buildTarGz(t, tt.in)
+			defer cancel()
+			var stargzBuf bytes.Buffer
+			w := stargz.NewWriter(&stargzBuf)
+			if err := w.AppendTar(tr); err != nil {
+				t.Fatalf("Append: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("Writer.Close: %v", err)
+			}
+			b := stargzBuf.Bytes()
+
+			r, err := stargz.Open(io.NewSectionReader(bytes.NewReader(b), 0, int64(len(b))))
+			if err != nil {
+				t.Fatalf("stargz.Open: %v", err)
+			}
+			root, ok := r.Lookup("")
+			if !ok {
+				t.Fatalf("failed to find root in stargz")
+			}
+			for _, want := range tt.want {
+				want.check(t, &node{
+					te:    root,
+					sr:    r,
+					child: make(map[string]fspkg.Node),
+				})
+			}
+		})
+	}
+}
+
+func buildTarGz(t *testing.T, ents []tarEntry) (r io.Reader, cancel func()) {
+	pr, pw := io.Pipe()
+	go func() {
+		tw := tar.NewWriter(pw)
+		for _, ent := range ents {
+			if err := ent.appendTar(tw); err != nil {
+				t.Errorf("building input tar: %v", err)
+				pw.Close()
+				return
+			}
+		}
+		if err := tw.Close(); err != nil {
+			t.Errorf("closing write of input tar: %v", err)
+		}
+		pw.Close()
+		return
+	}()
+	return pr, func() { go pr.Close(); go pw.Close() }
+}
+
+func tarOf(s ...tarEntry) []tarEntry { return s }
+
+func checks(s ...crfsCheck) []crfsCheck { return s }
+
+type tarEntry interface {
+	appendTar(*tar.Writer) error
+}
+
+type tarEntryFunc func(*tar.Writer) error
+
+func (f tarEntryFunc) appendTar(tw *tar.Writer) error { return f(tw) }
+
+func file(name, contents string) tarEntry {
+	return tarEntryFunc(func(tw *tar.Writer) error {
+		if strings.HasSuffix(name, "/") {
+			return fmt.Errorf("bogus trailing slash in file %q", name)
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     name,
+			Mode:     0644,
+			Size:     int64(len(contents)),
+		}); err != nil {
+			return err
+		}
+		_, err := io.WriteString(tw, contents)
+		return err
+	})
+}
+
+func dir(d string, opts ...interface{}) tarEntry {
+	return tarEntryFunc(func(tw *tar.Writer) error {
+		var xattrs xAttr
+		for _, opt := range opts {
+			if v, ok := opt.(xAttr); ok {
+				xattrs = v
+			} else {
+				return fmt.Errorf("unsupported opt")
+			}
+		}
+		name := string(d)
+		if !strings.HasSuffix(name, "/") {
+			panic(fmt.Sprintf("missing trailing slash in dir %q ", name))
+		}
+		return tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     name,
+			Mode:     0755,
+			Xattrs:   xattrs,
+		})
+	})
+}
+
+type xAttr map[string]string
+
+type crfsCheck interface {
+	check(t *testing.T, root *node)
+}
+
+type crfsCheckFn func(*testing.T, *node)
+
+func (f crfsCheckFn) check(t *testing.T, root *node) { f(t, root) }
+
+func fileNotExist(file string) crfsCheck {
+	return crfsCheckFn(func(t *testing.T, root *node) {
+		_, _, err := getDirentAndNode(root, file)
+		if err == nil {
+			t.Errorf("Node %q exists", file)
+		}
+	})
+}
+
+func hasFileDigest(file string, digest string) crfsCheck {
+	return crfsCheckFn(func(t *testing.T, root *node) {
+		_, ni, err := getDirentAndNode(root, file)
+		if err != nil {
+			t.Fatalf("failed to get node %q: %v", file, err)
+		}
+		n, ok := ni.(*node)
+		if !ok {
+			t.Fatalf("file %q isn't a normal node", file)
+		}
+		if n.te.Digest != digest {
+			t.Fatalf("Digest(%q) = %q, want %q", file, n.te.Digest, digest)
+		}
+	})
+}
+
+func hasValidWhiteout(name string) crfsCheck {
+	return crfsCheckFn(func(t *testing.T, root *node) {
+		ent, n, err := getDirentAndNode(root, name)
+		if err != nil {
+			t.Fatalf("failed to get node %q: %v", name, err)
+		}
+		var a fuse.Attr
+		if err := n.Attr(context.Background(), &a); err != nil {
+			t.Fatalf("failed to get attributes of file %q: %v", name, err)
+		}
+		if a.Inode != ent.Inode {
+			t.Errorf("inconsistent inodes %d(Node) != %d(Dirent)", a.Inode, ent.Inode)
+			return
+		}
+
+		// validate the direntry
+		if ent.Type != fuse.DT_Char {
+			t.Errorf("whiteout %q isn't a char device", name)
+			return
+		}
+
+		// validate the node
+		if a.Mode != os.ModeDevice|os.ModeCharDevice {
+			t.Errorf("whiteout %q has an invalid mode %o; want %o",
+				name, a.Mode, os.ModeDevice|os.ModeCharDevice)
+			return
+		}
+		if a.Rdev != uint32(unix.Mkdev(0, 0)) {
+			t.Errorf("whiteout %q has invalid device numbers (%d, %d); want (0, 0)",
+				name, unix.Major(uint64(a.Rdev)), unix.Minor(uint64(a.Rdev)))
+			return
+		}
+	})
+}
+
+func hasNodeXattrs(entry, name, value string) crfsCheck {
+	return crfsCheckFn(func(t *testing.T, root *node) {
+		_, ni, err := getDirentAndNode(root, entry)
+		if err != nil {
+			t.Fatalf("failed to get node %q: %v", entry, err)
+		}
+		n, ok := ni.(*node)
+		if !ok {
+			t.Fatalf("node %q isn't a normal node", entry)
+		}
+
+		// check xattr exists in the xattrs list.
+		listres := fuse.ListxattrResponse{}
+		if err := n.Listxattr(context.Background(), &fuse.ListxattrRequest{}, &listres); err != nil {
+			t.Fatalf("failed to get xattrs list of node %q: %v", entry, err)
+		}
+		xattrs := bytes.Split(listres.Xattr, []byte{0})
+		var found bool
+		for _, x := range xattrs {
+			if string(x) == name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("node %q doesn't have an opaque xattr %q", entry, opaqueXattr)
+			return
+		}
+
+		// check the xattr has valid value.
+		getres := fuse.GetxattrResponse{}
+		if err := n.Getxattr(context.Background(), &fuse.GetxattrRequest{Name: name}, &getres); err != nil {
+			t.Fatalf("failed to get xattr %q of node %q: %v", opaqueXattr, entry, err)
+		}
+		if string(getres.Xattr) != value {
+			t.Errorf("node %q has an invalid opaque directory xattr %q; want %q",
+				entry, getres.Xattr, opaqueXattrValue)
+			return
+		}
+	})
+}
+
+// getDirentAndNode gets dirent and node at the specified path at once and makes
+// sure that the both of them exist.
+func getDirentAndNode(root *node, path string) (ent fuse.Dirent, n fspkg.Node, err error) {
+	dir, base := filepath.Split(filepath.Clean(path))
+
+	// get the target's parent directory.
+	d := root
+	for _, name := range strings.Split(dir, "/") {
+		if len(name) == 0 {
+			continue
+		}
+		var di fspkg.Node
+		di, err = d.Lookup(context.Background(), name)
+		if err != nil {
+			return
+		}
+		var ok bool
+		d, ok = di.(*node)
+		if !ok {
+			err = fmt.Errorf("directory %q isn't a normal node", name)
+			return
+		}
+	}
+
+	// get the target's direntry.
+	dhi, err := d.Open(context.Background(), &fuse.OpenRequest{Dir: true}, &fuse.OpenResponse{})
+	if err != nil {
+		return
+	}
+	dh, ok := dhi.(*nodeHandle)
+	if !ok {
+		err = fmt.Errorf("the parent directory of %q isn't a normal node", path)
+		return
+	}
+	var ents []fuse.Dirent
+	ents, err = dh.ReadDirAll(context.Background())
+	if err != nil {
+		return
+	}
+	var found bool
+	for _, e := range ents {
+		if e.Name == base {
+			ent, found = e, true
+		}
+	}
+	if !found {
+		err = fmt.Errorf("direntry %q not found in the parent directory of %q", base, path)
+		return
+	}
+
+	// get the target's node.
+	if n, err = d.Lookup(context.Background(), base); err != nil {
+		return
+	}
+
+	return
+}
+
+func digestFor(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return fmt.Sprintf("sha256:%x", sum)
 }


### PR DESCRIPTION
Fixes: #40

To remove entries, current CRFS' behaviour doesn't make overlayfs happy because
overlayfs has a convention to express whiteouts different from the convention
defined in OCI(docker-compliant). This commit solves this issue.

See also:
- OCI spec: https://github.com/opencontainers/image-spec/blob/775207bd45b6cb8153ce218cc59351799217451f/layer.md#whiteouts
- Docker spec: https://github.com/moby/moby/blob/64fd3dc0d5e0b15246dcf8d2a58baf202cc179bc/image/spec/v1.2.md#creating-an-image-filesystem-changeset
- overlayfs: https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt

Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>