### PR TITLE
stargz: regFileEntry might be nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Discussion: https://github.com/golang/go/issues/30829
 container image, served directly from a container registry (such as
 [gcr.io](https://gcr.io/)), without pulling it all locally first.
 
+
+## Update
+
+This version of `stargz` is slightly different from Google's `stargz`.
+The origin format may case `Gzip(TarF(file1) + TarHeader(file2)) + GZip(TarF(file2) + TarFooter)`.
+This schema changes it to `Gzip(Tar(file1)) + Gzip(TarHeader(file2)) + GZip(TarF(file2)) + GZip(TarFooter)`.
+
+
+
 ## Background
 
 Starting a container should be fast. Currently, however, starting a

--- a/crfs.go
+++ b/crfs.go
@@ -42,9 +42,9 @@ import (
 	"bazil.org/fuse"
 	fspkg "bazil.org/fuse/fs"
 	"cloud.google.com/go/compute/metadata"
-	"github.com/google/crfs/stargz"
 	namepkg "github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
+	"github.com/mc256/crfs/stargz"
 	"golang.org/x/sys/unix"
 )
 

--- a/crfs_test.go
+++ b/crfs_test.go
@@ -19,7 +19,7 @@ import (
 
 	"bazil.org/fuse"
 	fspkg "bazil.org/fuse/fs"
-	"github.com/google/crfs/stargz"
+	"github.com/mc256/crfs/stargz"
 	"golang.org/x/sys/unix"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/crfs
+module github.com/mc256/crfs
 
 go 1.12
 

--- a/stargz/stargz.go
+++ b/stargz/stargz.go
@@ -785,7 +785,7 @@ func (w *Writer) AppendTar(r io.Reader) error {
 		} else {
 			w.toc.Entries = append(w.toc.Entries, ent)
 		}
-		if payloadDigest != nil {
+		if regFileEntry != nil && payloadDigest != nil {
 			regFileEntry.Digest = fmt.Sprintf("sha256:%x", payloadDigest.Sum(nil))
 		}
 		if err := tw.Flush(); err != nil {

--- a/stargz/stargz.go
+++ b/stargz/stargz.go
@@ -187,6 +187,8 @@ type TOCEntry struct {
 	ChunkOffset int64 `json:"chunkOffset,omitempty"`
 	ChunkSize   int64 `json:"chunkSize,omitempty"`
 
+	CompressedSize int64 `json:"compressedSize,omitempty"`
+
 	children map[string]*TOCEntry
 }
 
@@ -573,7 +575,7 @@ func NewWriter(w io.Writer) *Writer {
 	return &Writer{
 		bw:       bw,
 		cw:       cw,
-		toc:      &jtoc{Version: 1},
+		toc:      &jtoc{Version: 2},
 		diffHash: sha256.New(),
 	}
 }
@@ -755,11 +757,16 @@ func (w *Writer) AppendTar(r io.Reader) error {
 			var written int64
 			totalSize := ent.Size // save it before we destroy ent
 			tee := io.TeeReader(tr, payloadDigest)
+			didWrite := false
+			var prevEnt *TOCEntry
+			prevEnt = nil
 			for written < totalSize {
 				if err := w.closeGz(); err != nil {
 					return err
 				}
-
+				if prevEnt != nil {
+					prevEnt.CompressedSize = w.cw.n - prevEnt.Offset
+				}
 				chunkSize := int64(w.chunkSize())
 				remain := totalSize - written
 				if remain < chunkSize {
@@ -771,16 +778,27 @@ func (w *Writer) AppendTar(r io.Reader) error {
 				ent.ChunkOffset = written
 
 				w.condOpenGz()
-
+				didWrite = true
 				if _, err := io.CopyN(tw, tee, chunkSize); err != nil {
 					return fmt.Errorf("error copying %q: %v", h.Name, err)
 				}
+				prevEnt = ent
 				w.toc.Entries = append(w.toc.Entries, ent)
 				written += chunkSize
+
 				ent = &TOCEntry{
 					Name: h.Name,
 					Type: "chunk",
 				}
+			}
+			if didWrite {
+				if err := w.closeGz(); err != nil {
+					return err
+				}
+				if prevEnt != nil {
+					prevEnt.CompressedSize = w.cw.n - prevEnt.Offset
+				}
+				w.condOpenGz()
 			}
 		} else {
 			w.toc.Entries = append(w.toc.Entries, ent)
@@ -791,6 +809,7 @@ func (w *Writer) AppendTar(r io.Reader) error {
 		if err := tw.Flush(); err != nil {
 			return err
 		}
+
 	}
 	return nil
 }

--- a/stargz/stargzify/stargzify.go
+++ b/stargz/stargzify/stargzify.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/crfs/stargz"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -31,6 +30,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/stream"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/mc256/crfs/stargz"
 )
 
 var (


### PR DESCRIPTION
If the type of file is not `TypeReg`, then `payloadDigest` will be `nil`. 
But I think it would be great to make that pointer is not nil.