### PR TITLE
stargz: add json tag for numLink

### DIFF
--- a/stargz/stargz.go
+++ b/stargz/stargz.go
@@ -166,7 +166,7 @@ type TOCEntry struct {
 
 	// NumLink is the number of entry names pointing to this entry.
 	// Zero means one name references this entry.
-	NumLink int
+	NumLink int `json:"-"`
 
 	// Xattrs are the extended attribute for the entry.
 	Xattrs map[string][]byte `json:"xattrs,omitempty"`


### PR DESCRIPTION
stargz.index.json from `ghcr.io/stargz-containers/node:17.8.0-esgz`

main
```json
{
	"version": 1,
	"entries": [
		{
			"name": ".no.prefetch.landmark",
			"type": "reg",
			"size": 1,
			"offset": 85,
			"NumLink": 0,
			"digest": "sha256:dc0e9c3658a1a3ed1ec94274d8b19925c93e1abb7ddba294923ad9bde30f8cb8",
			"chunkDigest": "sha256:dc0e9c3658a1a3ed1ec94274d8b19925c93e1abb7ddba294923ad9bde30f8cb8"
		},
		...
}
```
pr 
```json
{
	"version": 1,
	"entries": [
		{
			"name": ".no.prefetch.landmark",
			"type": "reg",
			"size": 1,
			"offset": 85,
			"digest": "sha256:dc0e9c3658a1a3ed1ec94274d8b19925c93e1abb7ddba294923ad9bde30f8cb8",
			"chunkDigest": "sha256:dc0e9c3658a1a3ed1ec94274d8b19925c93e1abb7ddba294923ad9bde30f8cb8"
		},
		...
}
```

Better make NumLink to numLink keep field name consistency.